### PR TITLE
Pad zeros for missing months

### DIFF
--- a/static/chart-bymonth.js
+++ b/static/chart-bymonth.js
@@ -59,7 +59,7 @@ async function drawByMonthChart(eventNamesToShow = ['all'], yearsToShow = ['all'
   const datasets = rawDatasets.filter(x => {
     return eventNamesToShow.includes('all') || eventNamesToShow.includes(x.label);
   });
-  const monthLabels = Object.keys(yearFilteredData);
+  const monthLabels = buildContinuousMonthRange(yearFilteredData);
 
   if(charts.byMonthChart){
     charts.byMonthChart.clear();
@@ -97,14 +97,39 @@ async function drawByMonthChart(eventNamesToShow = ['all'], yearsToShow = ['all'
 function buildMonthDatasets(data){
 
   const allNames = allEventNames(data);
+  const allMonthKeys = buildContinuousMonthRange(data);
 
   // each event is a series
   return allNames.map(eventName => {
-    const series = Object.entries(data).map(e => e[1][eventName] || 0);
+
+    const series = allMonthKeys.map(month => {
+      if(!data[month]) return 0;
+      return data[month][eventName] || 0;
+    });
     return {
       label: eventName,
       borderColor: stringToColor(eventName),
       data: series
     }
   });
+}
+
+function buildContinuousMonthRange(data){
+  const firstMonth = Object.keys(data)[0];
+  const lastMonth = Object.keys(data).slice(-1)[0];
+  const [y,m] = firstMonth.split(/-/);
+  var [year,month] = [parseInt(y), parseInt(m)];
+  var date = `${year}-${pad2(month)}`;
+  const result = [];
+  do {
+    result.push(date);
+    month++;
+    if(month > 12){
+      month = 1;
+      year++;
+    }
+    date = `${year}-${pad2(month)}`;
+  } while(date !== lastMonth)
+  result.push(lastMonth);
+  return result;
 }

--- a/static/data-utils.js
+++ b/static/data-utils.js
@@ -106,13 +106,15 @@ function buildDateRange(first, last){
 
 function formatDate(d){
   const yyyy = '' + d.getFullYear();
-  var mm = '' + (d.getMonth()+1);
-  if(mm.length < 2){
-    mm = '0' + mm;
-  }
-  var dd = '' + d.getDate();
-  if(dd.length < 2){
-    dd = '0' + dd;
-  }
+  var mm = pad2(d.getMonth()+1);
+  var dd = pad2(d.getDate());
   return `${yyyy}-${mm}-${dd}`;
+}
+
+function pad2(value){
+  var result = '' + value;
+  if(result.length < 2){
+    return '0' + result;
+  }
+  return result;
 }


### PR DESCRIPTION
Apparently there are entire months missing from the source data, so pad it out with zeros.

This probably helps with #17.

The monthly looks like this now:
![image](https://user-images.githubusercontent.com/1888255/101310015-98d33280-3802-11eb-80f4-647b8e6b7cdd.png)
(previously Q1 2019 was just skipped in the x axis).
