### PR TITLE
rollup opensignal by month in the UI

### DIFF
--- a/static/chart-bymonth.js
+++ b/static/chart-bymonth.js
@@ -59,7 +59,7 @@ async function drawByMonthChart(eventNamesToShow = ['operator'], yearsToShow = [
   const datasets = rawDatasets.filter(x => {
     return eventNamesToShow.includes('all') || eventNamesToShow.includes(x.label);
   });
-  const monthLabels = buildContinuousMonthRange(yearFilteredData);
+  const monthLabels = buildContinuousMonthRangeFromData(yearFilteredData);
 
   if(charts.byMonthChart){
     charts.byMonthChart.clear();
@@ -97,7 +97,7 @@ async function drawByMonthChart(eventNamesToShow = ['operator'], yearsToShow = [
 function buildMonthDatasets(data){
 
   const allNames = allEventNames(data);
-  const allMonthKeys = buildContinuousMonthRange(data);
+  const allMonthKeys = buildContinuousMonthRangeFromData(data);
 
   // each event is a series
   return allNames.map(eventName => {
@@ -114,22 +114,8 @@ function buildMonthDatasets(data){
   });
 }
 
-function buildContinuousMonthRange(data){
-  const firstMonth = Object.keys(data)[0];
-  const lastMonth = Object.keys(data).slice(-1)[0];
-  const [y,m] = firstMonth.split(/-/);
-  var [year,month] = [parseInt(y), parseInt(m)];
-  var date = `${year}-${pad2(month)}`;
-  const result = [];
-  do {
-    result.push(date);
-    month++;
-    if(month > 12){
-      month = 1;
-      year++;
-    }
-    date = `${year}-${pad2(month)}`;
-  } while(date !== lastMonth)
-  result.push(lastMonth);
-  return result;
+function buildContinuousMonthRangeFromData(data){
+  const first = Object.keys(data)[0];
+  const last = Object.keys(data).slice(-1)[0];
+  return buildContinuousMonthRange(first, last);
 }

--- a/static/chart-opensignal.js
+++ b/static/chart-opensignal.js
@@ -2,10 +2,11 @@ function drawAllOpenSignal() {
   fetch('./data/openSignal.json')
     .then(response => response.json())
     .then(data => {
-      drawOpenSignalHandsetMenu(data);
-      drawOpenSignalRemoteMenu(data);
-      drawOpenSignalHandsetContent(data);
-      drawOpenSignalRemoteContent(data);
+      const monthData = rollupOpenSignalToMonths(data);
+      drawOpenSignalHandsetMenu(monthData);
+      drawOpenSignalRemoteMenu(monthData);
+      drawOpenSignalHandsetContent(monthData);
+      drawOpenSignalRemoteContent(monthData);
     });
 }
 
@@ -30,7 +31,7 @@ function drawOpenSignalRemoteMenu(data) {
 }
 
 function drawOpenSignalMenu(opts) {
-  const series = buildDateSeries(opts.data);
+  const series = openSignalMonthRangeFromObj(opts.data);
   const labels = Object.keys(series);
   const data = Object.values(series);
 
@@ -68,10 +69,9 @@ function drawOpenSignalRemoteContent(data) {
 }
 
 function drawOpenSignalContent(opts) {
-  const [start, end] = dateRangeMultiSeries(opts.multiSeries);
-  const peoplesHomesData = buildDateSeriesRange(opts.multiSeries.peoples_homes, start, end);
-  const conversationsData = buildDateSeriesRange(opts.multiSeries.conversations, start, end);
-  const missedConnData = buildDateSeriesRange(opts.multiSeries.missed_connections, start, end);
+  const peoplesHomesData = openSignalMonthRangeFromObj(opts.multiSeries.peoples_homes);
+  const conversationsData = openSignalMonthRangeFromObj(opts.multiSeries.conversations);
+  const missedConnData = openSignalMonthRangeFromObj(opts.multiSeries.missed_connections);
 
   const datasets = [
     {
@@ -104,6 +104,56 @@ function drawOpenSignalContent(opts) {
   });
 }
 
+function rollupOpenSignalToMonths(data){
+  const allMonths = openSignalMonthRange(data);
+
+  return {
+    handsetPickups: rollupMonths(allMonths, data.handsetPickups),
+    remoteMenu: rollupMonths(allMonths, data.remoteMenu),
+    handsetContent: Object.fromEntries(
+      Object.entries(data.handsetContent).map(e => [e[0], rollupMonths(allMonths, e[1])])
+    ),
+    remoteContent: Object.fromEntries(
+      Object.entries(data.remoteContent).map(e => [e[0], rollupMonths(allMonths, e[1])])
+    ),
+  };
+}
+
+function openSignalMonthRange(data){
+  const months = new Set();
+  addUniqueMonths(data.handsetPickups, months);
+  addUniqueMonths(data.remoteMenu, months);
+  Object.values(data.handsetContent).forEach(obj => addUniqueMonths(obj, months));
+  Object.values(data.remoteContent).forEach(obj => addUniqueMonths(obj, months));
+  return openSignalMonthRangeFromSet(months);
+}
+
+function openSignalMonthRangeFromObj(obj){
+  const months = new Set();
+  Object.keys(obj).forEach(m => months.add(m));
+  return rollupMonths(openSignalMonthRangeFromSet(months), obj, x=>x);
+}
+
+function openSignalMonthRangeFromSet(months){
+  const sorted = [...months].sort();
+  const first = sorted[0];
+  const last = sorted.slice(-1)[0];
+  return buildContinuousMonthRange(first, last);
+}
+
+function addUniqueMonths(obj, set){
+  Object.keys(obj).map(d => d.replace(/-\d\d$/, '')).forEach(d => set.add(d));
+}
+
+function rollupMonths(allMonths, obj, dateToMonth = d => d.replace(/-\d\d$/, '')){
+  const result = Object.fromEntries(allMonths.map(m => [m,0]));
+  return Object.entries(obj).reduce((acc,e) => {
+    const month = dateToMonth(e[0]);
+    result[month] += e[1];
+    return result;
+  }, result);
+}
+
 function dateRangeMultiSeries(data) {
   const all = Object.values(data);
   const allBounds = all.flatMap(series => {
@@ -112,17 +162,4 @@ function dateRangeMultiSeries(data) {
   });
   const sorted = allBounds.sort();
   return [new Date(sorted[0]), new Date(sorted.slice(-1)[0])];
-}
-
-// ensures the data has consistent date range (no date gaps)
-function buildDateSeries(data) {
-  const first = new Date(Object.keys(data)[0]);
-  const last = new Date(Object.keys(data).slice(-1)[0]);
-  return buildDateSeriesRange(data, first, last);
-}
-
-function buildDateSeriesRange(data, first, last) {
-  const result = buildDateRange(first, last);
-  const entries = result.map(d => [d, data[d] || 0]);
-  return Object.fromEntries(entries);
 }

--- a/static/data-utils.js
+++ b/static/data-utils.js
@@ -95,6 +95,24 @@ function buildDateRange(first, last){
   return result;
 }
 
+function buildContinuousMonthRange(first, last){
+  const [y,m] = first.split(/-/);
+  var [year,month] = [parseInt(y), parseInt(m)];
+  var date = `${year}-${pad2(month)}`;
+  const result = [];
+  do {
+    result.push(date);
+    month++;
+    if(month > 12){
+      month = 1;
+      year++;
+    }
+    date = `${year}-${pad2(month)}`;
+  } while(date !== last)
+  result.push(last);
+  return result;
+}
+
 function formatDate(d){
   const yyyy = '' + d.getFullYear();
   var mm = pad2(d.getMonth()+1);


### PR DESCRIPTION
This resolves #21.

It does not address the stretch goal of being able to toggle (was easier this way since the data is nested).