### PR TITLE
add event "presets" for monthly

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -13,6 +13,7 @@
   <script src="chart-yearsummary.js"></script>
   <script src="ui-utils.js"></script>
   <script src="data-utils.js"></script>
+  <script src="presets.js"></script>
 </head>
 <body>
 
@@ -41,6 +42,12 @@
       <option selected='true'>2018</option>
       <option selected='true'>2019</option>
       <option selected='true'>2020</option>
+    </select>
+    <br/>
+    <b>Presets:</b>
+    <br/>
+    <select id="bymonthpresets" name="bymonthpresets" size='5'>
+
     </select>
     <br/>
     <b>EVENTS:</b>

--- a/static/presets-bymonth.json
+++ b/static/presets-bymonth.json
@@ -1,0 +1,11 @@
+{
+  "operator": [
+    "operator", "operator-nopickup"
+  ],
+  "outgoing-ivr": [
+    "outgoing-ivr",
+    "outgoing-ivr-detroit",
+    "outgoing-ivr-souwester",
+    "outgoing-ivr-ypsi"
+  ]
+}

--- a/static/presets.js
+++ b/static/presets.js
@@ -11,11 +11,9 @@ function fetchByMonthPresets(){
 
 function configurePresetsFor(mappings, presetId, targetId){
   const presetSel = document.getElementById(presetId);
-  Object.entries(mappings).forEach(e => {
-    const source = e[0];
-    const targets = e[1];
+  Object.keys(mappings).forEach(preset => {
     const option = document.createElement('option');
-    option.text = source;
+    option.text = preset;
     presetSel.add(option);
   });
   presetSel.addEventListener('change', () => {

--- a/static/presets.js
+++ b/static/presets.js
@@ -1,0 +1,33 @@
+
+async function configurePresets() {
+  const monthlyPresets = await fetchByMonthPresets();
+  configurePresetsFor(monthlyPresets, 'bymonthpresets', 'bymonthsel');
+}
+
+function fetchByMonthPresets(){
+  return fetch('./presets-bymonth.json')
+    .then(response => response.json());
+}
+
+function configurePresetsFor(mappings, presetId, targetId){
+  const presetSel = document.getElementById(presetId);
+  Object.entries(mappings).forEach(e => {
+    const source = e[0];
+    const targets = e[1];
+    const option = document.createElement('option');
+    option.text = source;
+    presetSel.add(option);
+  });
+  presetSel.addEventListener('change', () => {
+    const targets = mappings[presetSel.value];
+    for (const option of document.querySelectorAll(`#${targetId} option`)) {
+      if(targets.includes(option.value)){
+        option.setAttribute('selected', true);
+      }
+      else{
+        option.removeAttribute('selected');
+      }
+    }
+    document.getElementById(targetId).dispatchEvent(new Event('change'));
+  });
+}

--- a/static/webapp.js
+++ b/static/webapp.js
@@ -8,6 +8,7 @@ drawByDateChart();
 drawByMonthChart();
 drawYearSummary();
 drawByFoneChart();
+configurePresets();
 
 function updateHandlers(){
   document.getElementById("byhoursel")


### PR DESCRIPTION
This adds some monthly "presets" for groups of events.  Choosing one of these presets will cause a set of predefined events to be selected.  So far, only operator related and ivr related presets were defined...but the `presets-bymonth.json` file shows how to pretty simply define more.

Relates to #35...but maybe doesn't close it because it because maybe we want presets on the "by date" and/or "by fone" screens as well?  @kra?  My preference would be to close out #35 and make smaller, more specific issues for the other screens.